### PR TITLE
feat(auth): add forgot password flow with instruction section, shared…

### DIFF
--- a/__tests__/app/forgot-password/component/forgot-password-form.test.tsx
+++ b/__tests__/app/forgot-password/component/forgot-password-form.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { ForgotPasswordForm } from "@/app/[locale]/forgot-password/component";
+
+// Mock the useAppStateStore hook
+jest.mock("@/store", () => ({
+  useAppStateStore: jest.fn(),
+}));
+
+describe("ForgotPasswordForm", () => {
+  it("renders the Forgot text", () => {
+    // Mock setIsLoading as a jest function
+    const setIsLoading = jest.fn();
+    // @ts-ignore
+    require("@/store").useAppStateStore.mockReturnValue({ setIsLoading });
+
+    const { getByText } = render(<ForgotPasswordForm />);
+    expect(getByText("Forgot")).toBeInTheDocument();
+  });
+
+  it("calls setIsLoading(false) on mount", () => {
+    const setIsLoading = jest.fn();
+    // @ts-ignore
+    require("@/store").useAppStateStore.mockReturnValue({ setIsLoading });
+
+    render(<ForgotPasswordForm />);
+    expect(setIsLoading).toHaveBeenCalledWith(false);
+  });
+});

--- a/__tests__/app/forgot-password/layout.test.tsx
+++ b/__tests__/app/forgot-password/layout.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import ForgotPasswordLayout from "../../../app/[locale]/forgot-password/layout";
+
+// Mock the ForgotPasswordInstructionSection component
+jest.mock("../../../app/[locale]/forgot-password/section", () => ({
+  ForgotPasswordInstructionSection: (props: any) => (
+    <div
+      data-testid={
+        props["data-testid"] || "forgot-password-instruction-section"
+      }
+    >
+      Mocked Instruction Section
+    </div>
+  ),
+}));
+
+describe("ForgotPasswordLayout", () => {
+  it("renders the main layout with correct test id", () => {
+    render(
+      <ForgotPasswordLayout>
+        <div>Test Child</div>
+      </ForgotPasswordLayout>
+    );
+    expect(
+      screen.getByTestId("forgot-password-layout-main")
+    ).toBeInTheDocument();
+  });
+
+  it("renders the ForgotPasswordInstructionSection", () => {
+    render(
+      <ForgotPasswordLayout>
+        <div>Test Child</div>
+      </ForgotPasswordLayout>
+    );
+    expect(
+      screen.getByTestId("forgot-password-instruction-section")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("forgot-password-instruction-section")
+    ).toHaveTextContent("Mocked Instruction Section");
+  });
+
+  it("renders the section with children and correct test id", () => {
+    render(
+      <ForgotPasswordLayout>
+        <span data-testid="child-element">Test Child</span>
+      </ForgotPasswordLayout>
+    );
+    const section = screen.getByTestId("forgot-password-layout-section");
+    expect(section).toBeInTheDocument();
+    expect(screen.getByTestId("child-element")).toBeInTheDocument();
+    expect(section).toContainElement(screen.getByTestId("child-element"));
+  });
+});

--- a/__tests__/app/forgot-password/section/forgot-password-instruction-section.test.tsx
+++ b/__tests__/app/forgot-password/section/forgot-password-instruction-section.test.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ForgotPasswordInstructionSection } from "@/app/[locale]/forgot-password/section";
+const { usePathname } = require("next/navigation");
+
+// Mocks
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(),
+}));
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+jest.mock("@/lib", () => ({
+  translate: (_t: any, key: string) => `translated:${key}`,
+}));
+jest.mock("@/components/auth-instruction/instruction-badge", () => ({
+  __esModule: true,
+  default: ({ number, title }: { number: number; title: string }) => (
+    <div data-testid="instruction-badge">{`${number}-${title}`}</div>
+  ),
+}));
+jest.mock("@/components/auth-instruction/instruction-container", () => ({
+  InstructionContainer: ({
+    title,
+    subTitle,
+    topBadge,
+    topBadgeTitleKey,
+  }: any) => (
+    <div>
+      <div data-testid="title">{title}</div>
+      <div data-testid="subtitle">{subTitle}</div>
+      <div data-testid="topBadgeTitleKey">{topBadgeTitleKey}</div>
+      <div data-testid="topBadge">{topBadge}</div>
+    </div>
+  ),
+}));
+jest.mock("@/config", () => ({
+  PATH: {
+    FORGOT_PASSWORD: { path: "/forgot-password" },
+    FORGOT_PASSWORD_OTP: { path: "/forgot-password/otp" },
+    FORGOT_PASSWORD_RESET: { path: "/forgot-password/reset" },
+    REGISTER: { path: "/register" },
+  },
+}));
+
+describe("ForgotPasswordInstructionSection", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders enter email instruction for /forgot-password", () => {
+    usePathname.mockReturnValue("/forgot-password");
+    render(<ForgotPasswordInstructionSection />);
+    expect(screen.getByTestId("title").textContent).toBe(
+      "forgotPassword.instruction.enterEmail.title"
+    );
+    expect(screen.getByTestId("subtitle").textContent).toBe(
+      "forgotPassword.instruction.enterEmail.subtitle"
+    );
+    expect(screen.getByTestId("topBadgeTitleKey").textContent).toBe(
+      "forgotPassword.instruction.enterEmail.topBadge.title"
+    );
+    const badges = screen.getAllByTestId("instruction-badge");
+    expect(badges).toHaveLength(2);
+    expect(badges[0].textContent).toBe(
+      "1-translated:forgotPassword.instruction.enterEmail.topBadge.badgeTitle.1"
+    );
+    expect(badges[1].textContent).toBe(
+      "2-translated:forgotPassword.instruction.enterEmail.topBadge.badgeTitle.2"
+    );
+  });
+
+  it("renders OTP instruction for /forgot-password/otp", () => {
+    usePathname.mockReturnValue("/forgot-password/otp");
+    render(<ForgotPasswordInstructionSection />);
+    expect(screen.getByTestId("title").textContent).toBe(
+      "forgotPassword.instruction.otp.title"
+    );
+    expect(screen.getAllByTestId("instruction-badge")).toHaveLength(3);
+  });
+
+  it("renders reset instruction for /forgot-password/reset", () => {
+    usePathname.mockReturnValue("/forgot-password/reset");
+    render(<ForgotPasswordInstructionSection />);
+    expect(screen.getByTestId("title").textContent).toBe(
+      "forgotPassword.instruction.reset.title"
+    );
+    expect(screen.getAllByTestId("instruction-badge")).toHaveLength(3);
+  });
+
+  it("strips locale prefix from pathname", () => {
+    usePathname.mockReturnValue("/en/forgot-password");
+    render(<ForgotPasswordInstructionSection />);
+    expect(screen.getByTestId("title").textContent).toBe(
+      "forgotPassword.instruction.enterEmail.title"
+    );
+  });
+});

--- a/app/[locale]/forgot-password/component/forgot-password-form.tsx
+++ b/app/[locale]/forgot-password/component/forgot-password-form.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useAppStateStore } from "@/store";
-import { set } from "date-fns";
 import React, { useEffect } from "react";
 
 export function ForgotPasswordForm() {

--- a/app/[locale]/forgot-password/component/forgot-password-form.tsx
+++ b/app/[locale]/forgot-password/component/forgot-password-form.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useAppStateStore } from "@/store";
+import { set } from "date-fns";
+import React, { useEffect } from "react";
+
+export function ForgotPasswordForm() {
+  const { setIsLoading } = useAppStateStore();
+
+  useEffect(() => {
+    setIsLoading(false);
+  }, [setIsLoading]);
+
+  return <div>Forgot</div>;
+}

--- a/app/[locale]/forgot-password/component/index.ts
+++ b/app/[locale]/forgot-password/component/index.ts
@@ -1,0 +1,1 @@
+export * from "./forgot-password-form";

--- a/app/[locale]/forgot-password/layout.tsx
+++ b/app/[locale]/forgot-password/layout.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { InstructionSection } from "./section";
+import { ForgotPasswordInstructionSection } from "./section";
 
 export default function ForgotPasswordLayout({
   children,
@@ -11,7 +11,7 @@ export default function ForgotPasswordLayout({
       className="flex min-h-screen bg-neutral-50"
       data-testid="forgot-password-layout-main"
     >
-      <InstructionSection />
+      <ForgotPasswordInstructionSection data-testid="forgot-password-instruction-section" />
       <section
         className="basis-8/12 flex justify-center items-center"
         data-testid="forgot-password-layout-section"

--- a/app/[locale]/forgot-password/layout.tsx
+++ b/app/[locale]/forgot-password/layout.tsx
@@ -14,7 +14,7 @@ export default function ForgotPasswordLayout({
       <InstructionSection />
       <section
         className="basis-8/12 flex justify-center items-center"
-        data-testi="forgot-password-layout-section"
+        data-testid="forgot-password-layout-section"
       >
         {children}
       </section>

--- a/app/[locale]/forgot-password/layout.tsx
+++ b/app/[locale]/forgot-password/layout.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { InstructionSection } from "./section";
+
+export default function ForgotPasswordLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <main
+      className="flex min-h-screen bg-neutral-50"
+      data-testid="forgot-password-layout-main"
+    >
+      <InstructionSection />
+      <section
+        className="basis-8/12 flex justify-center items-center"
+        data-testi="forgot-password-layout-section"
+      >
+        {children}
+      </section>
+    </main>
+  );
+}

--- a/app/[locale]/forgot-password/otp/page.tsx
+++ b/app/[locale]/forgot-password/otp/page.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function OtpPage() {
+  return <div>Otp</div>;
+}

--- a/app/[locale]/forgot-password/page.tsx
+++ b/app/[locale]/forgot-password/page.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { ForgotPasswordForm } from "./component";
+
+export default function ForgotPasswordPage() {
+  return <ForgotPasswordForm />;
+}

--- a/app/[locale]/forgot-password/reset/page.tsx
+++ b/app/[locale]/forgot-password/reset/page.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function ResetPage() {
+  return <div>ResetPage</div>;
+}

--- a/app/[locale]/forgot-password/section/forgot-password-instruction-section.tsx
+++ b/app/[locale]/forgot-password/section/forgot-password-instruction-section.tsx
@@ -16,7 +16,7 @@ const INSTRUCTION_CONFIG: Record<string, InstructionConfig> = {
     topBadgeData: {
       count: 2,
       keyPrefix: "forgotPassword.instruction.enterEmail.topBadge.badgeTitle",
-    }
+    },
   },
   [PATH.FORGOT_PASSWORD_OTP.path]: {
     title: "forgotPassword.instruction.otp.title",
@@ -25,7 +25,7 @@ const INSTRUCTION_CONFIG: Record<string, InstructionConfig> = {
     topBadgeData: {
       count: 3,
       keyPrefix: "forgotPassword.instruction.otp.topBadge.badgeTitle",
-    }
+    },
   },
   [PATH.FORGOT_PASSWORD_RESET.path]: {
     title: "forgotPassword.instruction.reset.title",
@@ -34,7 +34,7 @@ const INSTRUCTION_CONFIG: Record<string, InstructionConfig> = {
     topBadgeData: {
       count: 3,
       keyPrefix: "forgotPassword.instruction.reset.topBadge.badgeTitle",
-    }
+    },
   },
 };
 
@@ -51,7 +51,7 @@ const useInstructionConfig = (
   );
 };
 
-export function InstructionSection() {
+export function ForgotPasswordInstructionSection() {
   const t = useTranslations();
   const pathname = usePathname();
   const config = useInstructionConfig(pathname);

--- a/app/[locale]/forgot-password/section/forgot-password-instruction-section.tsx
+++ b/app/[locale]/forgot-password/section/forgot-password-instruction-section.tsx
@@ -47,7 +47,7 @@ const useInstructionConfig = (
     : pathname;
   return (
     INSTRUCTION_CONFIG[currentPathname] ||
-    INSTRUCTION_CONFIG[PATH.REGISTER.path]
+    INSTRUCTION_CONFIG[PATH.FORGOT_PASSWORD.path]
   );
 };
 

--- a/app/[locale]/forgot-password/section/index.ts
+++ b/app/[locale]/forgot-password/section/index.ts
@@ -1,0 +1,1 @@
+export * from "./instruction-section";

--- a/app/[locale]/forgot-password/section/index.ts
+++ b/app/[locale]/forgot-password/section/index.ts
@@ -1,1 +1,1 @@
-export * from "./instruction-section";
+export * from "./forgot-password-instruction-section";

--- a/app/[locale]/forgot-password/section/instruction-section.tsx
+++ b/app/[locale]/forgot-password/section/instruction-section.tsx
@@ -2,11 +2,11 @@
 
 import { useTranslations } from "next-intl";
 import { InstructionConfig, PATH } from "@/config";
-import { TxKeyPath } from "@/i18n/i18n";
 import { usePathname } from "next/navigation";
 import InstructionBadge from "@/components/auth-instruction/instruction-badge";
 import { translate } from "@/lib";
 import { InstructionContainer } from "@/components/auth-instruction/instruction-container";
+import { TxKeyPath } from "@/i18n";
 
 const INSTRUCTION_CONFIG: Record<string, InstructionConfig> = {
   [PATH.FORGOT_PASSWORD.path]: {
@@ -16,9 +16,7 @@ const INSTRUCTION_CONFIG: Record<string, InstructionConfig> = {
     topBadgeData: {
       count: 2,
       keyPrefix: "forgotPassword.instruction.enterEmail.topBadge.badgeTitle",
-    },
-    bottomBadgeData: undefined,
-    bottomBadgeTitleKey: undefined,
+    }
   },
   [PATH.FORGOT_PASSWORD_OTP.path]: {
     title: "forgotPassword.instruction.otp.title",
@@ -27,9 +25,7 @@ const INSTRUCTION_CONFIG: Record<string, InstructionConfig> = {
     topBadgeData: {
       count: 3,
       keyPrefix: "forgotPassword.instruction.otp.topBadge.badgeTitle",
-    },
-    bottomBadgeData: undefined,
-    bottomBadgeTitleKey: undefined,
+    }
   },
   [PATH.FORGOT_PASSWORD_RESET.path]: {
     title: "forgotPassword.instruction.reset.title",
@@ -38,9 +34,7 @@ const INSTRUCTION_CONFIG: Record<string, InstructionConfig> = {
     topBadgeData: {
       count: 3,
       keyPrefix: "forgotPassword.instruction.reset.topBadge.badgeTitle",
-    },
-    bottomBadgeData: undefined,
-    bottomBadgeTitleKey: undefined,
+    }
   },
 };
 

--- a/app/[locale]/forgot-password/section/instruction-section.tsx
+++ b/app/[locale]/forgot-password/section/instruction-section.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { InstructionConfig, PATH } from "@/config";
+import { TxKeyPath } from "@/i18n/i18n";
+import { usePathname } from "next/navigation";
+import InstructionBadge from "@/components/auth-instruction/instruction-badge";
+import { translate } from "@/lib";
+import { InstructionContainer } from "@/components/auth-instruction/instruction-container";
+
+const INSTRUCTION_CONFIG: Record<string, InstructionConfig> = {
+  [PATH.FORGOT_PASSWORD.path]: {
+    title: "forgotPassword.instruction.enterEmail.title",
+    subTitle: "forgotPassword.instruction.enterEmail.subtitle",
+    topBadgeTitleKey: "forgotPassword.instruction.enterEmail.topBadge.title",
+    topBadgeData: {
+      count: 2,
+      keyPrefix: "forgotPassword.instruction.enterEmail.topBadge.badgeTitle",
+    },
+    bottomBadgeData: undefined,
+    bottomBadgeTitleKey: undefined,
+  },
+  [PATH.FORGOT_PASSWORD_OTP.path]: {
+    title: "forgotPassword.instruction.otp.title",
+    subTitle: "forgotPassword.instruction.otp.subtitle",
+    topBadgeTitleKey: "forgotPassword.instruction.otp.topBadge.title",
+    topBadgeData: {
+      count: 3,
+      keyPrefix: "forgotPassword.instruction.otp.topBadge.badgeTitle",
+    },
+    bottomBadgeData: undefined,
+    bottomBadgeTitleKey: undefined,
+  },
+  [PATH.FORGOT_PASSWORD_RESET.path]: {
+    title: "forgotPassword.instruction.reset.title",
+    subTitle: "forgotPassword.instruction.reset.subtitle",
+    topBadgeTitleKey: "forgotPassword.instruction.reset.topBadge.title",
+    topBadgeData: {
+      count: 3,
+      keyPrefix: "forgotPassword.instruction.reset.topBadge.badgeTitle",
+    },
+    bottomBadgeData: undefined,
+    bottomBadgeTitleKey: undefined,
+  },
+};
+
+const useInstructionConfig = (
+  pathname: string
+): (typeof INSTRUCTION_CONFIG)[keyof typeof INSTRUCTION_CONFIG] => {
+  const localeMatch = pathname.match(/^\/([a-z]{2})(\/|$)/);
+  const currentPathname = localeMatch
+    ? pathname.replace(/^\/[a-z]{2}/, "")
+    : pathname;
+  return (
+    INSTRUCTION_CONFIG[currentPathname] ||
+    INSTRUCTION_CONFIG[PATH.REGISTER.path]
+  );
+};
+
+export function InstructionSection() {
+  const t = useTranslations();
+  const pathname = usePathname();
+  const config = useInstructionConfig(pathname);
+
+  const topBadge = config.topBadgeData ? (
+    <>
+      {Array.from({ length: config.topBadgeData.count }).map((_, idx) => (
+        <InstructionBadge
+          key={idx}
+          number={idx + 1}
+          title={translate(
+            t,
+            `${config.topBadgeData?.keyPrefix}.${idx + 1}` as TxKeyPath
+          )}
+        />
+      ))}
+    </>
+  ) : null;
+
+  return (
+    <InstructionContainer
+      title={config.title}
+      subTitle={config.subTitle}
+      topBadge={topBadge}
+      topBadgeTitleKey={config.topBadgeTitleKey}
+    />
+  );
+}

--- a/app/[locale]/login/components/email-form.tsx
+++ b/app/[locale]/login/components/email-form.tsx
@@ -87,7 +87,6 @@ export function EmailForm() {
             onClick={() => setIsLoading(true)}
             data-testid="forgot-password-link"
             aria-label="Forgot Password"
-            type="button"
             className="justify-self-end text-label text-main-700 cursor-pointer hover:underline"
           >
             {translate(t, "login.form.signIn.button.forgotPassword")}

--- a/app/[locale]/login/components/email-form.tsx
+++ b/app/[locale]/login/components/email-form.tsx
@@ -82,9 +82,16 @@ export function EmailForm() {
             labelKey={"register.form.signUp.input.label.password"}
             placeholderKey={"register.form.signUp.input.placeholder.password"}
           />
-          <button className="justify-self-end text-label text-main-700 cursor-pointer hover:underline">
+          <Link
+            href={PATH.FORGOT_PASSWORD.getPath(getCurrentLocale())}
+            onClick={() => setIsLoading(true)}
+            data-testid="forgot-password-link"
+            aria-label="Forgot Password"
+            type="button"
+            className="justify-self-end text-label text-main-700 cursor-pointer hover:underline"
+          >
             {translate(t, "login.form.signIn.button.forgotPassword")}
-          </button>
+          </Link>
         </div>
         <Button type="submit">
           {translate(t, "login.form.signIn.button.signIn")}

--- a/app/[locale]/login/tests/components/divider-form.test.tsx
+++ b/app/[locale]/login/tests/components/divider-form.test.tsx
@@ -28,6 +28,6 @@ describe("DividerForm", () => {
     render(<DividerForm />);
     const dividerText = screen.getByTestId("divider-text");
     expect(dividerText).toBeInTheDocument();
-    expect(dividerText).toHaveTextContent("register.form.signUp.or");
+    expect(dividerText).toHaveTextContent("login.form.signIn.or");
   });
 });

--- a/app/[locale]/register/section/instruction-section.tsx
+++ b/app/[locale]/register/section/instruction-section.tsx
@@ -1,26 +1,11 @@
 "use client";
 import InstructionBadge from "@/components/auth-instruction/instruction-badge";
 import { InstructionContainer } from "@/components/auth-instruction/instruction-container";
-import { PATH } from "@/config";
+import { InstructionConfig, PATH } from "@/config";
 import { TxKeyPath } from "@/i18n";
 import { translate } from "@/lib";
 import { useTranslations } from "next-intl";
 import { usePathname } from "next/navigation";
-
-type InstructionConfig = {
-  title: TxKeyPath;
-  subTitle: TxKeyPath;
-  topBadgeTitleKey: TxKeyPath;
-  bottomBadgeTitleKey?: TxKeyPath;
-  topBadgeData?: {
-    count: number;
-    keyPrefix: string;
-  };
-  bottomBadgeData?: {
-    count: number;
-    keyPrefix: string;
-  };
-};
 
 const INSTRUCTION_CONFIG: Record<string, InstructionConfig> = {
   [PATH.REGISTER.path]: {

--- a/components/auth-instruction/instruction-badge.tsx
+++ b/components/auth-instruction/instruction-badge.tsx
@@ -10,7 +10,7 @@ export default function InstructionBadge({
   return (
     <div
       data-testid={`instruction-badge-wrapper-${number}`}
-      className="flex gap-2 bg-[#B6C2D3]/40 p-6 rounded-4xl"
+      className="flex gap-2 bg-[#B6C2D3]/40 p-6 rounded-4xl items-center"
     >
       <div className="flex items-center justify-center bg-neutral-50 w-6 h-6 rounded-full text-neutral-950 text-body-normal">
         {number}

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,2 +1,3 @@
 export * from "./path";
 export * from "./config";
+export * from "./types";

--- a/config/path.ts
+++ b/config/path.ts
@@ -16,6 +16,27 @@ export const PATH: PathInterface = {
     getPath: (locale: string) => `/${locale}/login`,
     isProtected: false,
   },
+  FORGOT_PASSWORD: {
+    name: "forgot-password",
+    path: "/forgot-password",
+    value: "forgot-password",
+    getPath: (locale: string) => `/${locale}/forgot-password`,
+    isProtected: false,
+  },
+  FORGOT_PASSWORD_OTP: {
+    name: "forgot-password-otp",
+    path: "/forgot-password/otp",
+    value: "forgot-password-otp",
+    getPath: (locale: string) => `/${locale}/forgot-password/otp`,
+    isProtected: false,
+  },
+  FORGOT_PASSWORD_RESET: {
+    name: "forgot-password-reset",
+    path: "/forgot-password/reset",
+    value: "forgot-password-reset",
+    getPath: (locale: string) => `/${locale}/forgot-password/reset`,
+    isProtected: false,
+  },
   HOME: {
     name: "home",
     path: "/home",

--- a/config/types.ts
+++ b/config/types.ts
@@ -1,0 +1,16 @@
+import { TxKeyPath } from "@/i18n";
+
+export type InstructionConfig = {
+  title: TxKeyPath;
+  subTitle: TxKeyPath;
+  topBadgeTitleKey: TxKeyPath;
+  bottomBadgeTitleKey?: TxKeyPath;
+  topBadgeData?: {
+    count: number;
+    keyPrefix: string;
+  };
+  bottomBadgeData?: {
+    count: number;
+    keyPrefix: string;
+  };
+};

--- a/messages/en.json
+++ b/messages/en.json
@@ -195,7 +195,7 @@
       },
       "reset": {
         "title": "Reset your password",
-        "subtitle": "Create a new password to regain access",
+        "subtitle": "Create a new password to regain access.",
         "topBadge": {
           "title": "Reset Password Steps:",
           "badgeTitle": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -167,5 +167,44 @@
         "or": "Or"
       }
     }
+  },
+  "forgotPassword": {
+    "instruction": {
+      "enterEmail": {
+        "title": "Forgot your password?",
+        "subtitle": "Enter your registered email or phone number to reset your password.",
+        "topBadge": {
+          "title": "Steps to reset your password:",
+          "badgeTitle": {
+            "1": "Enter your registered email address or phone number.",
+            "2": "Click the submit button to receive a verification code."
+          }
+        }
+      },
+      "otp": {
+        "title": "OTP Verification",
+        "subtitle": "Enter the code sent to your email or phone number to continue.",
+        "topBadge": {
+          "title": "OTP Verification Steps:",
+          "badgeTitle": {
+            "1": "Check your email or phone for the 4-digit code.",
+            "2": "Enter the code in the field below.",
+            "3": "Click verify to continue."
+          }
+        }
+      },
+      "reset": {
+        "title": "Reset your password",
+        "subtitle": "Create a new password to regain access",
+        "topBadge": {
+          "title": "Reset Password Steps:",
+          "badgeTitle": {
+            "1": "Enter your new password.",
+            "2": "Re-enter your new password to confirm.",
+            "3": "Click Save Password to complete the reset."
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
… config, and improved navigation

- Add redirection to sign up page from login if user doesn't have an account
- Create layout and pages for forgot-password, OTP, and reset password
- Implement instruction section for forgot-password, OTP, and reset password pages
- Refactor auth instruction badge alignment to center
- Move instruction config type to config types for reuse
- Add PATH entries for forgot-password, OTP, and reset password
- Add i18n translations for forgot-password, OTP, and reset password instructions