### PR TITLE
feat(i18n,auth): add error message translations, backend key translat…

### DIFF
--- a/app/[locale]/login/components/email-form.tsx
+++ b/app/[locale]/login/components/email-form.tsx
@@ -69,7 +69,12 @@ export function EmailForm() {
       })
       .catch((e) => {
         const data: ExoPortalErrorMessage = e.response?.data;
-        handleErrorMessage(data, form, ["email", "password"]);
+        handleErrorMessage({
+          data: data,
+          form: form,
+          allowedFields: ["email", "password"],
+          useTranslate: t,
+        });
       })
       .finally(() => {
         setIsLoading(false);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,9 +1,11 @@
 import { clsx, type ClassValue } from "clsx";
-import { Locale } from "next-intl";
+import { Locale, useTranslations } from "next-intl";
 import { twMerge } from "tailwind-merge";
 import { parsePhoneNumberFromString, AsYouType } from "libphonenumber-js";
 import { UseFormReturn } from "react-hook-form";
 import { ExoPortalErrorMessage } from "@/config";
+import { translate } from "./translate";
+import { TxKeyPath } from "@/i18n";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -63,11 +65,17 @@ export const metaDataTitle = (title: string): string => {
   return `${title} | ExoPortal`;
 };
 
-export function handleErrorMessage<T extends string>(
-  data: ExoPortalErrorMessage,
-  form: UseFormReturn<any>,
-  allowedFields: T[]
-) {
+export function handleErrorMessage<T extends string>({
+  data,
+  form,
+  allowedFields,
+  useTranslate,
+}: {
+  data: ExoPortalErrorMessage;
+  form: UseFormReturn<any>;
+  allowedFields: T[];
+  useTranslate: ReturnType<typeof useTranslations>;
+}) {
   if (
     typeof data?.errorType === "string" &&
     data.errorType.toLowerCase() === "field"
@@ -78,7 +86,7 @@ export function handleErrorMessage<T extends string>(
           if (allowedFields.includes(err.fieldName as T)) {
             form.setError(err.fieldName as T, {
               type: "manual",
-              message: err.errorMessage,
+              message: translate(useTranslate, err.errorMessage as TxKeyPath),
             });
             form.setFocus(err.fieldName as T);
           }

--- a/messages/en.json
+++ b/messages/en.json
@@ -6,6 +6,10 @@
   "common": {
     "back": "Back"
   },
+  "errorMessage": {
+    "emailAlreadyExists": "Email already exists.",
+    "invalidEmailAndPassword": "Invalid email or password."
+  },
   "register": {
     "instruction": {
       "register": {


### PR DESCRIPTION
…ion, and email existence validation

- Added new translation messages for error handling in en.json
- Updated handleErrorMessage to translate backend error keys
- Register email form now validates email existence via backend API
- Unified error handling with translation in both Register and Login forms